### PR TITLE
Persist $STACK env variable

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -8,4 +8,5 @@ config_vars:
   LD_LIBRARY_PATH: /app/packages/lib
   LUA_CPATH: ./?.so;/app/packages/lib/lua/5.1/?.so
   LUA_PATH: ./?.lua;/app/packages/share/lua/5.1/?.lua;/app/packages/share/lua/5.1/?/init.lua
+  STACK: $STACK
 EOF


### PR DESCRIPTION
Otherwise this variable is only available during the buildpack compile step (see: https://devcenter.heroku.com/articles/buildpack-api#stacks)
It is useful to have it always available so that an application can be deployed in a different way based on the stack.
