### PR TITLE
Set PATH and other vars in .profile.d script

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -56,3 +56,12 @@ fi
 
 $LUA "$OPT_DIR/prepare.lua" $ROCKSPEC $OPT_DIR 2>&1 | indent
 
+# Setting environment variables in .profile.d script (sourced at dyno startup)
+mkdir -p "$BUILD_DIR"/.profile.d
+cat <<EOF >"$BUILD_DIR"/.profile.d/lua.sh
+PATH=/app/bin:\$PATH
+export LD_LIBRARY_PATH=/app/packages/lib:$LD_LIBRARY_PATH
+export LUA_CPATH="./?.so;/app/packages/lib/lua/5.1/?.so"
+export LUA_PATH="./?.lua;/app/packages/share/lua/5.1/?.lua;/app/packages/share/lua/5.1/?/init.lua"
+export STACK=$STACK
+EOF

--- a/bin/release
+++ b/bin/release
@@ -3,10 +3,4 @@
 
 cat << EOF
 ---
-config_vars:
-  PATH: /app/bin:/usr/local/bin:/usr/bin:/bin
-  LD_LIBRARY_PATH: /app/packages/lib
-  LUA_CPATH: ./?.so;/app/packages/lib/lua/5.1/?.so
-  LUA_PATH: ./?.lua;/app/packages/share/lua/5.1/?.lua;/app/packages/share/lua/5.1/?/init.lua
-  STACK: $STACK
 EOF


### PR DESCRIPTION
I moved the setting of the config vars from the YAML hash in the `release` script to the `.profile.d` script. This should fix the problem that the config vars, including the PATH, might not be set if the buildpack is used together with other buildpacks (see issue #3 which would be fixed with this).

Setting config vars in the `release` script also seems to be deprecated, as it is not mentioned here https://devcenter.heroku.com/articles/buildpack-api#buildpack-api (under bin/release), and here https://devcenter.heroku.com/articles/buildpack-api#default-config-values it is advised to use a `.profile.d` script for adding default config values.
