### PR TITLE
print errors returned from luarocks.install.run()

### DIFF
--- a/opt/prepare.lua
+++ b/opt/prepare.lua
@@ -75,5 +75,8 @@ if not success then
 end
 for _index_0 = 1, #extras do
   local extra = extras[_index_0]
-  install.run(extra)
+  ok, err, exitcode = install.run(extra)
+  if not ok then
+    error(err)
+  end
 end


### PR DESCRIPTION
before this fix if a Luarock failed to install the build process would continue normally without printing the error and without returning a non-zero status code

This could lead to serious problems when deploying apps as the deploy process would report success and deploy a non working application

@leafo Would appreciate your review
